### PR TITLE
R Server build error

### DIFF
--- a/ops/kubernetes.deployment.yaml
+++ b/ops/kubernetes.deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: willitscale-r-server
-          image: stacktical/willitscale-r-server:1.0
+          image: stacktical/willitscale-r-server:1.1
           ports:
             - containerPort: 6311
 ---

--- a/r-server/install-packages.R
+++ b/r-server/install-packages.R
@@ -4,7 +4,6 @@ install.packages("ggplot2")
 
 library("versions")
 install.versions("jsonlite","1.3")
-install.versions("rstan","2.17.3")
 
 install.packages("nlmrt")
 


### PR DESCRIPTION
This fixes #4 by removing a trailing dependency (RStan) from the R server build sequence. 

A new `willitscale-r-server` version 1.1 has been pushed to the Stacktical Docker registry for Kubernetes deployment. See https://hub.docker.com/repository/docker/stacktical/willitscale-r-server/tags?page=1